### PR TITLE
Added random latency to SQS receives.

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -174,6 +174,7 @@ func SendMessage(w http.ResponseWriter, req *http.Request) {
 	msg.MD5OfMessageBody = common.GetMD5Hash(messageBody)
 	msg.Uuid, _ = common.NewUUID()
 	msg.GroupID = messageGroupID
+	msg.SentTime = time.Now()
 
 	app.SyncQueues.Lock()
 	fifoSeqNumber := ""
@@ -300,6 +301,7 @@ func SendMessageBatch(w http.ResponseWriter, req *http.Request) {
 		msg.MD5OfMessageBody = common.GetMD5Hash(sendEntry.MessageBody)
 		msg.GroupID = sendEntry.MessageGroupId
 		msg.Uuid, _ = common.NewUUID()
+		msg.SentTime = time.Now()
 		app.SyncQueues.Lock()
 		fifoSeqNumber := ""
 		if app.SyncQueues.Queues[queueName].IsFIFO {
@@ -401,6 +403,9 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 			uuid, _ := common.NewUUID()
 
 			msg := &app.SyncQueues.Queues[queueName].Messages[i]
+			if !msg.IsReadyForReceipt() {
+				continue
+			}
 			msg.ReceiptHandle = msg.Uuid + "#" + uuid
 			msg.ReceiptTime = time.Now().UTC()
 			msg.VisibilityTimeout = time.Now().Add(time.Duration(app.SyncQueues.Queues[queueName].TimeoutSecs) * time.Second)

--- a/app/sqs_test.go
+++ b/app/sqs_test.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestMessage_IsReadyForReceipt(t *testing.T) {
+	os.Setenv("GOAWS_RANDOM_LATENCY_MIN", "100")
+	os.Setenv("GOAWS_RANDOM_LATENCY_MAX", "100")
+	msg := Message{
+		SentTime:               time.Now(),
+	}
+	assert.False(t, msg.IsReadyForReceipt())
+	duration, _ := time.ParseDuration("105ms")
+	time.Sleep(duration)
+	assert.True(t, msg.IsReadyForReceipt())
+}


### PR DESCRIPTION
Latency is based on the inclusion of two environment variables
(GOAWS_RANDOM_LATENCY_MIN and GOAWS_RANDOM_LATENCY_MAX), which, if set
will prevent messages from being released from the queue until after a
period of random, simulated latency has elapsed.

The purpose of this change is to aid in local testing against AWS when
SQS latency is expected and needs to be developed against.